### PR TITLE
Add Göteborgsvarvet support and refactor spider for multi-provider

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -224,24 +224,19 @@ df_participants, df_times, df_paces = event_data
 mask = pd.Series(True, index=df_participants.index)
 
 #### Gender ####
-can_filter_on_gender_male = any(
-    item.startswith("H") for item in df_participants["age_class"].unique()
-)
-can_filter_on_gender_female = any(
-    item.startswith("D") for item in df_participants["age_class"].unique()
-)
+# Known gender prefix pairs: Vasaloppet uses H/D, Göteborgsvarvet uses M/K
+GENDER_PREFIX_PAIRS = [("H", "D"), ("M", "K")]
 
-selected_gender = st.sidebar.selectbox(
-    "Filter by Gender",
-    (
-        ["All"]
-        + (
-            ["H", "D"]
-            if (can_filter_on_gender_male and can_filter_on_gender_female)
-            else []
-        )
-    ),
-)
+gender_options = ["All"]
+unique_classes = df_participants["age_class"].unique()
+for male_prefix, female_prefix in GENDER_PREFIX_PAIRS:
+    has_male = any(item.startswith(male_prefix) for item in unique_classes)
+    has_female = any(item.startswith(female_prefix) for item in unique_classes)
+    if has_male and has_female:
+        gender_options.extend([male_prefix, female_prefix])
+        break
+
+selected_gender = st.sidebar.selectbox("Filter by Gender", gender_options)
 if selected_gender != "All":
     mask_gender = df_participants["age_class"].str.startswith(selected_gender)
     mask &= mask_gender

--- a/app/main.py
+++ b/app/main.py
@@ -199,24 +199,19 @@ df_participants, df_times, df_paces = event_data
 mask = pd.Series(True, index=df_participants.index)
 
 #### Gender ####
-can_filter_on_gender_male = any(
-    item.startswith("H") for item in df_participants["age_class"].unique()
-)
-can_filter_on_gender_female = any(
-    item.startswith("D") for item in df_participants["age_class"].unique()
-)
+# Known gender prefix pairs: Vasaloppet uses H/D, Göteborgsvarvet uses M/K
+GENDER_PREFIX_PAIRS = [("H", "D"), ("M", "K")]
 
-selected_gender = st.sidebar.selectbox(
-    "Filter by Gender",
-    (
-        ["All"]
-        + (
-            ["H", "D"]
-            if (can_filter_on_gender_male and can_filter_on_gender_female)
-            else []
-        )
-    ),
-)
+gender_options = ["All"]
+unique_classes = df_participants["age_class"].unique()
+for male_prefix, female_prefix in GENDER_PREFIX_PAIRS:
+    has_male = any(item.startswith(male_prefix) for item in unique_classes)
+    has_female = any(item.startswith(female_prefix) for item in unique_classes)
+    if has_male and has_female:
+        gender_options.extend([male_prefix, female_prefix])
+        break
+
+selected_gender = st.sidebar.selectbox("Filter by Gender", gender_options)
 if selected_gender != "All":
     mask_gender = df_participants["age_class"].str.startswith(selected_gender)
     mask &= mask_gender

--- a/scraper/mikatiming_spider.py
+++ b/scraper/mikatiming_spider.py
@@ -24,8 +24,8 @@ def convert_time_to_seconds(time_str):
         return (hours * 3600) + (minutes * 60) + seconds
 
 
-class VasalyticsSpider(CrawlSpider):
-    name = "vasalytics"
+class MikaTimingSpider(CrawlSpider):
+    name = "mikatiming"
     rules = (
         Rule(
             LinkExtractor(restrict_css="ul.pagination > li.pages-nav-button"),
@@ -34,10 +34,10 @@ class VasalyticsSpider(CrawlSpider):
         Rule(LinkExtractor(allow=r"\?content=detail"), callback="parse_details"),
     )
 
-    def __init__(self, event_id, *args, **kwargs):
+    def __init__(self, event_id, base_url, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.start_urls = [f"https://results.vasaloppet.se/?event={event_id}&pid=list"]
+        self.start_urls = [f"{base_url}/?event={event_id}&pid=list"]
 
     def parse_details(self, response):
         """Extracts split data for each participant"""

--- a/scraper/providers/goteborgsvarvet.py
+++ b/scraper/providers/goteborgsvarvet.py
@@ -4,17 +4,17 @@ from providers.base import BaseProvider, EventInfo
 from mikatiming_spider import MikaTimingSpider
 
 
-class VasaloppetProvider(BaseProvider):
+class GoteborgsvarvetProvider(BaseProvider):
 
-    BASE_URL = "https://results.vasaloppet.se"
+    BASE_URL = "https://goteborgsvarvet.r.mikatiming.com"
 
     @property
     def name(self) -> str:
-        return "vasaloppet"
+        return "goteborgsvarvet"
 
     @property
     def label(self) -> str:
-        return "Vasaloppet"
+        return "Göteborgsvarvet"
 
     def discover_events(self) -> list[EventInfo]:
         events = []
@@ -34,14 +34,18 @@ class VasaloppetProvider(BaseProvider):
         return MikaTimingSpider
 
     def spider_kwargs(self, event: EventInfo) -> dict:
-        return {"event_id": event.event_id, "base_url": self.BASE_URL}
+        return {
+            "event_id": event.event_id,
+            "base_url": f"{self.BASE_URL}/{event.year}",
+        }
 
-    # --- Private helpers (moved from run_scraper.py) ---
+    # --- Private helpers ---
 
     def _get_years(self):
         response = requests.get(
-            "https://results.vasaloppet.se/index.php"
-            "?content=ajax2&func=getSearchFields&options"
+            f"{self.BASE_URL}/index.php"
+            "?content=ajax2&func=getSearchFields&options",
+            timeout=30,
         )
         response.raise_for_status()
         return [
@@ -52,11 +56,12 @@ class VasaloppetProvider(BaseProvider):
             if isinstance(item["v"][0], int)
         ]
 
-    def _get_events(self, year: int):
+    def _get_events(self, year: str):
         response = requests.get(
-            f"https://results.vasaloppet.se/2025/index.php"
+            f"{self.BASE_URL}/{year}/index.php"
             f"?content=ajax2&func=getSearchFields"
-            f"&options%5Bb%5D%5Blists%5D%5Bevent_main_group%5D={year}"
+            f"&options%5Bb%5D%5Blists%5D%5Bevent_main_group%5D={year}",
+            timeout=30,
         )
         response.raise_for_status()
         all_events = {

--- a/scraper/run_scraper.py
+++ b/scraper/run_scraper.py
@@ -6,12 +6,14 @@ from tqdm import tqdm
 from scrapy.crawler import CrawlerProcess
 
 from providers.vasaloppet import VasaloppetProvider
+from providers.goteborgsvarvet import GoteborgsvarvetProvider
 
 DATA_ROOT = Path(__file__).parent.parent / "data"
 
 # --- Provider registry ---
 PROVIDERS = [
     VasaloppetProvider(),
+    GoteborgsvarvetProvider(),
 ]
 
 


### PR DESCRIPTION
## Summary
This PR adds support for scraping Göteborgsvarvet race results and refactors the spider architecture to support multiple MikaTiming-based providers.

## Key Changes

- **New Provider**: Added `GoteborgsvarvetProvider` to scrape Göteborgsvarvet events from their MikaTiming instance
  - Implements event discovery by fetching available years and events from the MikaTiming API
  - Handles deduplication of events with the same name across seasons

- **Spider Refactoring**: Renamed `VasalyticsSpider` to `MikaTimingSpider` to reflect its generic MikaTiming compatibility
  - Made the spider base URL configurable via constructor parameter instead of hardcoding Vasaloppet URL
  - Updated `VasaloppetProvider` to pass the base URL when creating spider instances

- **Gender Filter Enhancement**: Updated gender filtering logic in both `app/main.py` and `app/index.html`
  - Now supports multiple gender prefix conventions (H/D for Vasaloppet, M/K for Göteborgsvarvet)
  - Uses a configurable `GENDER_PREFIX_PAIRS` list for extensibility

- **Provider Registry**: Updated `run_scraper.py` to include the new `GoteborgsvarvetProvider` in the provider list

## Implementation Details

The refactoring maintains backward compatibility with Vasaloppet while enabling support for other MikaTiming-based race events. The spider now accepts a `base_url` parameter, allowing it to work with different MikaTiming instances by simply changing the base URL configuration.

https://claude.ai/code/session_019wVktgxyDvdfMSs6FLE6be